### PR TITLE
Separate HELM creation of serviceAccount and RBAC

### DIFF
--- a/charts/aws-pca-issuer/templates/rbac.yaml
+++ b/charts/aws-pca-issuer/templates/rbac.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 ---
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/aws-pca-issuer/values.yaml
+++ b/charts/aws-pca-issuer/values.yaml
@@ -24,6 +24,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # Specifies whether RBAC should be created
+  create: true
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
This makes it possible to still create the necessary RBAC bindings when the serviceAccount is managed outside of the HELM deploy.

