### PR TITLE
Fix issue with CertificateRequest API Group check

### DIFF
--- a/pkg/controllers/certificaterequest_controller.go
+++ b/pkg/controllers/certificaterequest_controller.go
@@ -73,7 +73,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	if cr.Spec.IssuerRef.Group != "" && cr.Spec.IssuerRef.Group != api.GroupVersion.Group {
+	if cr.Spec.IssuerRef.Group != api.GroupVersion.Group {
 		log.V(4).Info("CertificateRequest does not specify an issuerRef matching our group")
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
`cr.Spec.IssuerRef.Group` could possibly be "" in cases where someone wishes to use an Issuer that comes with `cert-manager`, such as a self-signed issuer, and doesn't explicitly specify the API Goup as `cert-manager.io` in the created `Certificate` resource.

The `CertificateRequest` type (or more accurately, the `ObjectReference` type used for `IssuerRef`) doesn't require that `Group` be populated: https://github.com/jetstack/cert-manager/blob/0ff2b8778c51e6cebe140a6b196e7a9a28cbee87/pkg/apis/meta/v1/types.go#L52

Given that this would be a potentially breaking API change to require a `Group` upstream, I think this external issuer should assume the lack of a specified API Group means that it should ignore the resource.

